### PR TITLE
Added an option to skip Azure provider registration

### DIFF
--- a/infrastructure/provider.tf
+++ b/infrastructure/provider.tf
@@ -5,4 +5,5 @@ provider "azurerm" {
       prevent_deletion_if_contains_resources = false
     }
   }
+  skip_provider_registration = true
 }


### PR DESCRIPTION
Added an option to skip Azure provider registration.
`terraform plan` times out without this option.

With this option `terraform plan` and `terraform apply` work like a charm.