### PR TITLE
temurin install seems to be returning 403 for a few weeks now. 

### DIFF
--- a/infrastructure/scripts/install-tools.sh
+++ b/infrastructure/scripts/install-tools.sh
@@ -41,7 +41,7 @@ sudo mkdir -p /etc/apt/keyrings
 wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | sudo tee /etc/apt/keyrings/adoptium.asc
 echo "deb [signed-by=/etc/apt/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | sudo tee /etc/apt/sources.list.d/adoptium.list
 sudo apt update
-sudo apt install temurin-17-jdk -y
+sudo apt install openjdk-17-jdk -y
 
 # jq
 sudo apt-get --assume-yes install jq


### PR DESCRIPTION
This means that clout-init is failing to complete.
Switched to openjdk instead, seems to be working well.